### PR TITLE
fixes strange spacing in `r36s-set-volume.sh`

### DIFF
--- a/AmberELEC/usr/bin/r36s-set-volume.sh
+++ b/AmberELEC/usr/bin/r36s-set-volume.sh
@@ -1,16 +1,16 @@
-    #!/bin/bash
-    
-    vol_r36s=$(amixer sget 'Playback' | grep "Front Left:" | awk '{ print $4 }' | tr -d '[]')
-    last_vol=$(head -n 1 "/storage/.config/.volume")
+#!/bin/bash
 
-    mkdir -p /var/lib/alsa/
-    amixer sset 'Playback Path' SPK_HP
-    alsactl store
-    ln -s /dev/input/event3 /dev/input/by-path/platform-rg351-keys-event
-    systemctl restart volume.service
-    if [ -f "/storage/.config/.volume" ]; then
-        amixer sset 'Playback' ${last_vol}
-    else
-        amixer sset 'Playback' 75%
-    fi
-    exit
+vol_r36s=$(amixer sget 'Playback' | grep "Front Left:" | awk '{ print $4 }' | tr -d '[]')
+last_vol=$(head -n 1 "/storage/.config/.volume")
+
+mkdir -p /var/lib/alsa/
+amixer sset 'Playback Path' SPK_HP
+alsactl store
+ln -s /dev/input/event3 /dev/input/by-path/platform-rg351-keys-event
+systemctl restart volume.service
+if [ -f "/storage/.config/.volume" ]; then
+  amixer sset 'Playback' ${last_vol}
+else
+  amixer sset 'Playback' 75%
+fi
+exit


### PR DESCRIPTION
There was some strange whitespace in the sh