### PR TITLE
Fix netplay host launch crash due to --host being parsed as a key-value flag

### DIFF
--- a/AmberELEC/usr/bin/runemu.py
+++ b/AmberELEC/usr/bin/runemu.py
@@ -367,7 +367,9 @@ class EmuRunner():
                 command += ['--connect', self.args['connect'] +
                             '|' + self.args['port']]
             if 'host' in self.args:
-                command += ['--host', self.args['host']]
+                command.append('--host')
+                if 'port' in self.args:
+                    command += ['--port', self.args['port']]
 
             command += ['--nick', netplay_nick]
 
@@ -463,17 +465,21 @@ class EmuRunner():
 def main():
     time_started = perf_counter()
 
+    BOOLEAN_FLAGS = {'host'}
+
     i = 0
     args: dict[str, str] = {}
     while i < len(sys.argv) - 1:
         if sys.argv[i].startswith('--'):
-            args[sys.argv[i][2:]] = sys.argv[i + 1]
-            i += 1
-            continue
-        if sys.argv[i].startswith('-'):
+            key = sys.argv[i][2:]
+            if key in BOOLEAN_FLAGS:
+                args[key] = ''
+            else:
+                args[key] = sys.argv[i + 1]
+                i += 1
+        elif sys.argv[i].startswith('-'):
             args[sys.argv[i][1:]] = sys.argv[i + 1]
             i += 1
-            continue
         i += 1
 
     rom = Path(args['rom']) if 'rom' in args else None


### PR DESCRIPTION
### Summary
- Fix argument parser in `runemu.py` to handle `--host` as a boolean (standalone) flag, preventing it from consuming `--port` as its value
- Fix RetroArch command builder to pass `--host` standalone and `--port` as a separate argument
### Problem
When hosting a netplay game via the EmulationStation menu, the game crashes immediately with a generic error. Launching RetroArch directly and hosting from its menu works fine.
EmulationStation correctly passes: `--host --port 55435 --nick ilya`
But the argument parser in `runemu.py` treats every `--flag` as a key-value pair, consuming the next token as its value. This causes `--host` to eat `--port` as its value, producing:
args = {'host': '--port', 'port': '55435', 'nick': 'ilya'}

The command builder then passes `--host --port` (the string literal) to RetroArch, which is invalid and causes the crash.
### Fix
1. **Argument parser:** Added a `BOOLEAN_FLAGS` set containing `'host'`. When a boolean flag is encountered, it is stored with an empty string value without consuming the next token.
2. **Command builder:** Changed `get_retroarch_command` to append `--host` standalone (no value) and pass `--port <value>` as a separate argument when hosting.
The connect (client) path is unaffected since `--connect` correctly takes an IP address as its value.
